### PR TITLE
Upgrade node to version 8.x (latest LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - g++-4.8
 node_js:
   - node
-  - 6
+  - 8
 install:
   - make deps
 script:


### PR DESCRIPTION
This probably requires changes on the server where `krotoncheck` is deployed. Can't find any references to a dockerfile or something similar in this repo. `node 8` became the current `LTS` on [2017-10-31](https://github.com/nodejs/Release#release-schedule).